### PR TITLE
feat: 로그아웃 구현 및 Public, Private 라우터 적용, 내정보수정 레이아웃 수정

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,8 @@ import {
   PostDetailPage,
 } from '@pages';
 import { Topbar } from '@components/Bar';
+import PrivateRoute from '@utils/privateRoute';
+import PublicRoute from '@utils/publicRoute';
 
 function App() {
   return (
@@ -17,16 +19,16 @@ function App() {
       <Topbar />
       <Switch>
         <Route path="/" exact component={HomePage} />
-        <Route path="/signup" exact component={SignupPage} />
-        <Route path="/signin" exact component={SigninPage} />
-        <Route path="/my" component={MyPage} />
+        <PublicRoute exact from="/signup" to="/my" component={SignupPage} />
+        <PublicRoute exact from="/signin" to="/my" component={SigninPage} />
+        <PrivateRoute exact from="/my" component={MyPage} />
         <Route path="/player" exact component={HomePage} />
         <Route path="/coach" exact component={HomePage} />
         <Route path="/club" exact component={HomePage} />
-        <Route path="/write/player" exact component={PostWritePage} />
-        <Route path="/write/coach" exact component={PostWritePage} />
+        <PrivateRoute exact from="/write/player" component={PostWritePage} />
+        <PrivateRoute exact from="/write/coach" component={PostWritePage} />
         <Route path="/view" exact component={PostDetailPage} />
-        <Route path="/edit/:id" exact component={HomePage} />
+        <PrivateRoute exact from="/edit/:id" component={HomePage} />
       </Switch>
     </UserProvider>
   );

--- a/src/components/Bar/Sidebar.jsx
+++ b/src/components/Bar/Sidebar.jsx
@@ -2,12 +2,19 @@ import React from 'react';
 import styles from './Sidebar.module.scss';
 import classNames from 'classnames/bind';
 import { withRouter } from 'react-router-dom';
+import { useUsers } from '@contexts/UserProvider';
 
 const cx = classNames.bind(styles);
 
 const Sidebar = (props) => {
   const { className: rootClassName, history } = props;
   const className = cx(styles.root, rootClassName);
+  const { removeUser } = useUsers();
+
+  const handleClick = () => {
+    removeUser();
+  };
+
   return (
     <ul className={className}>
       <li
@@ -33,6 +40,9 @@ const Sidebar = (props) => {
         }}
       >
         내 게시판
+      </li>
+      <li className={cx(styles.list, styles.last__child)} onClick={handleClick}>
+        로그아웃
       </li>
     </ul>
   );

--- a/src/components/Bar/Sidebar.module.scss
+++ b/src/components/Bar/Sidebar.module.scss
@@ -5,11 +5,13 @@
   @include container__column();
   justify-content: flex-start;
   align-items: flex-start;
+  position: relative;
   width: 256px;
   background-color: $primary;
   flex-shrink: 0;
   margin-right: $main__margin__size;
   padding: 16px 0;
+  margin-bottom: 24px;
 }
 
 .list {
@@ -24,5 +26,10 @@
     background-color: $main__white;
     color: $primary;
     transition: color 500ms ease-in-out, background-color 500ms ease-in-out;
+  }
+
+  &.last__child {
+    position: absolute;
+    bottom: 16px;
   }
 }

--- a/src/components/Bar/Topbar.jsx
+++ b/src/components/Bar/Topbar.jsx
@@ -41,14 +41,13 @@ const Topbar = (props) => {
         </button>
       </div>
       <div className={styles.user}>
-        {/* 로그인? 마이페이지 : 로그인 */}
         <button
           type="button"
           onClick={() => {
             user ? history.push('/my') : history.push('/signin');
           }}
         >
-          {user ? '내정보' : '로그인'}
+          {user ? '마이페이지' : '로그인'}
         </button>
         <button
           type="button"

--- a/src/components/Form/MyInfoEditForm.jsx
+++ b/src/components/Form/MyInfoEditForm.jsx
@@ -36,7 +36,7 @@ const MyInfoEditForm = (props) => {
             className={styles.profile__image}
             src={
               values.srcUrl ||
-              'https://user-images.githubusercontent.com/69751205/165550742-f15e262d-8f90-4096-9dfa-30801c211827.png'
+              'https://user-images.githubusercontent.com/69751205/167300027-24e32d1c-984e-4f2d-b7d1-2cef9054a81e.png'
             }
             alt=""
           />

--- a/src/components/Form/MyInfoEditForm.module.scss
+++ b/src/components/Form/MyInfoEditForm.module.scss
@@ -4,6 +4,8 @@
 .root {
   @include container__column();
   width: 100%;
+  box-shadow: none;
+  margin-bottom: 24px;
 }
 
 .profile__wrapper {

--- a/src/contexts/UserProvider.js
+++ b/src/contexts/UserProvider.js
@@ -4,7 +4,8 @@ const UserContext = createContext();
 export const useUsers = () => useContext(UserContext);
 
 const UserProvider = ({ children }) => {
-  const [user, setUser] = useState('');
+  const isAuthorized = sessionStorage.getItem('authorization');
+  const [user, setUser] = useState(isAuthorized);
 
   const addUser = (token) => {
     sessionStorage.setItem('authorization', token);
@@ -13,6 +14,7 @@ const UserProvider = ({ children }) => {
 
   const removeUser = (id) => {
     sessionStorage.removeItem('authorization');
+    setUser();
   };
 
   return (

--- a/src/utils/privateRoute.jsx
+++ b/src/utils/privateRoute.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Redirect, Route } from 'react-router-dom';
+import { useUsers } from '@contexts/UserProvider';
+
+const PrivateRoute = ({ component: Component, from, to, ...props }) => {
+  const { user } = useUsers();
+  return (
+    <Route
+      {...props}
+      render={(props) =>
+        user || sessionStorage.getItem('authorization') ? (
+          <Component {...props} />
+        ) : (
+          <Redirect
+            to={{
+              pathname: to,
+              state: { from },
+            }}
+          />
+        )
+      }
+    />
+  );
+};
+
+export default PrivateRoute;

--- a/src/utils/publicRoute.jsx
+++ b/src/utils/publicRoute.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Redirect, Route } from 'react-router-dom';
+import { useUsers } from '@contexts/UserProvider';
+
+const PublicRoute = ({ component: Component, from, to, ...props }) => {
+  const { user } = useUsers();
+  return (
+    <Route
+      {...props}
+      render={(props) =>
+        user || sessionStorage.getItem('authorization') ? (
+          <Redirect
+            to={{
+              pathname: to,
+              state: { from },
+            }}
+          />
+        ) : (
+          <Component {...props} />
+        )
+      }
+    />
+  );
+};
+
+export default PublicRoute;


### PR DESCRIPTION
## 구현 사항
- 로그아웃 기능 구현
- 페이지 권한별 라우팅 처리
- 내정보수정 레이아웃 수정
- 기본 이미지 수정

## 구현 결과

![2022-05-09 00 08 06](https://user-images.githubusercontent.com/69751205/167302686-c1065671-47e7-411d-82f5-77dda9defa88.gif)

